### PR TITLE
support $unset with multiple keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,12 +105,19 @@ var defaultCommands = {
       'Did you forget to wrap the key(s) in an array?',
       value
     );
+    var deletingKeys = [];
     var originalValue = nextObject;
     for (var i = 0; i < value.length; i++) {
       var key = value[i];
       if (Object.hasOwnProperty.call(originalValue, key)) {
-        originalValue = nextObject === object ? copy(object) : nextObject;
-        delete originalValue[key];
+        deletingKeys.push(key);
+      }
+    }
+    if (deletingKeys.length > 0) {
+      originalValue = copy(object);
+      for (var j = 0; j < deletingKeys.length; j++) {
+        var deletingkey = deletingKeys[j];
+        delete originalValue[deletingkey];
       }
     }
     return originalValue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immutability-helper",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "mutate a copy of data without changing the original source",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -118,6 +118,14 @@ describe('update', function() {
       var removed = update({a: 'b'}, {$unset: ['a']});
       expect('a' in removed).toBe(false);
     });
+    it('removes multiple keys from the object', function() {
+      var original = {a: 'b', c: 'd', e: 'f'};
+      var removed = update(original, {$unset: ['a', 'e']});
+      expect('a' in removed).toBe(false);
+      expect('a' in original).toBe(true);
+      expect('e' in removed).toBe(false);
+      expect('e' in original).toBe(true);
+    });
     it('does not remove keys from the inherited properties', function() {
       function Parent() { this.foo = 'Parent'; }
       function Child() {}


### PR DESCRIPTION
The version 2.2.0 supports `unset` command (keeping reference equality when possible), but it seems that it does not support multiple keys:
```
// version 2.2.0
var original = {a: 'b', c: 'd', e: 'f'};

var result1 = update(original, {
  $unset: ['a']
});
// => {c: 'd', e: 'f'} works right

var result2 = update(original, {
  $unset: ['a', 'e']
});
// => {a: 'b', c: 'd'} works WRONG
```

This pr fixed the problem:
```
// version 2.2.1 with the pr
var original = {a: 'b', c: 'd', e: 'f'};

var result1 = update(original, {
  $unset: ['a']
});
// => {c: 'd', e: 'f'} works right

var result2 = update(original, {
  $unset: ['a', 'e']
});
// => {c: 'd'} works RIGHT
```
