### PR TITLE
fixed typo: remove unused line.

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,6 @@ function newContext() {
     );
 
     var nextObject = object;
-    var specKeys = getAllKeys(spec);
     var index, key;
     getAllKeys(spec).forEach(function(key) {
       if (hasOwnProperty.call(commands, key)) {


### PR DESCRIPTION
Remove the line in `update`, below:

```js
var specKeys = getAllKeys(spec);
```

Remove it can save some performance.