### PR TITLE
Fix #55

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function newContext() {
         }
       } else {
         var nextValueForKey = update(object[key], spec[key]);
-        if (!update.isEquals(nextValueForKey, nextObject[key])) {
+        if (!update.isEquals(nextValueForKey, nextObject[key]) || typeof nextValueForKey === 'undefined') {
           if (nextObject === object) {
             nextObject = copy(object);
           }

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function newContext() {
         }
       } else {
         var nextValueForKey = update(object[key], spec[key]);
-        if (!update.isEquals(nextValueForKey, nextObject[key]) || typeof nextValueForKey === 'undefined') {
+        if (!update.isEquals(nextValueForKey, nextObject[key]) || typeof nextValueForKey === 'undefined' && !hasOwnProperty.call(object, key)) {
           if (nextObject === object) {
             nextObject = copy(object);
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immutability-helper",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "mutate a copy of data without changing the original source",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -135,6 +135,13 @@ describe('update', function() {
       expect(update(original, {a: {$set: 1}})).toBe(original);
       expect(update(original, {a: {$set: 2}})).toNotBe(original);
     });
+    it('setting a property to undefined should add an enumerable key to final object with value undefined', function() {
+      var original = {a: 1};
+      var result = update(original, {b: {$set: undefined}});
+      expect(result).toNotBe(original);
+      expect(result).toEqual({a: 1, b: undefined});
+      expect(Object.keys(result).length).toEqual(2);
+    });
   });
 
   describe('$unset', function() {


### PR DESCRIPTION
Using $set to set a new property to undefined, now creates a new object with an enumerable own property set to undefined.

```js
const obj = immutabilityHelper({}, { x: { $set: undefined } })
Object.keys(obj) === ['x'] 
```