### PR TITLE
Add $toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The `$`-prefixed keys are called *commands*. The data structure they are "mutati
   * `{$unshift: array}` `unshift()` all the items in `array` on the target.
   * `{$splice: array of arrays}` for each item in `arrays` call `splice()` on the target with the parameters provided by the item. ***Note:** The items in the array are applied sequentially, so the order matters. The indices of the target may change during the operation.*
   * `{$set: any}` replace the target entirely.
-  * `{$toggle: any}` toggle a boolean field.
+  * `{$toggle: array of strings}` toggle a boolean field.
   * `{$unset: array of strings}` remove the list of keys in `array` from the target object.
   * `{$merge: object}` merge the keys of `object` with the target.
   * `{$apply: function}` passes in the current value to the function and updates it with the new returned value.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The `$`-prefixed keys are called *commands*. The data structure they are "mutati
   * `{$unshift: array}` `unshift()` all the items in `array` on the target.
   * `{$splice: array of arrays}` for each item in `arrays` call `splice()` on the target with the parameters provided by the item. ***Note:** The items in the array are applied sequentially, so the order matters. The indices of the target may change during the operation.*
   * `{$set: any}` replace the target entirely.
-  * `{$toggle: array of strings}` toggle a boolean field.
+  * `{$toggle: array of strings}` toggles a list of boolean fields from the target object.
   * `{$unset: array of strings}` remove the list of keys in `array` from the target object.
   * `{$merge: object}` merge the keys of `object` with the target.
   * `{$apply: function}` passes in the current value to the function and updates it with the new returned value.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The `$`-prefixed keys are called *commands*. The data structure they are "mutati
   * `{$unshift: array}` `unshift()` all the items in `array` on the target.
   * `{$splice: array of arrays}` for each item in `arrays` call `splice()` on the target with the parameters provided by the item. ***Note:** The items in the array are applied sequentially, so the order matters. The indices of the target may change during the operation.*
   * `{$set: any}` replace the target entirely.
+  * `{$toggle: any}` toggle a boolean field.
   * `{$unset: array of strings}` remove the list of keys in `array` from the target object.
   * `{$merge: object}` merge the keys of `object` with the target.
   * `{$apply: function}` passes in the current value to the function and updates it with the new returned value.

--- a/index.js
+++ b/index.js
@@ -103,7 +103,9 @@ var defaultCommands = {
   },
   $toggle: function(target, nextObject, spec) {
     invariantToggle(target, nextObject);
-    return assign({}, nextObject, {[target]: !nextObject[target]});
+    var nextObjectCopy = copy(nextObject);
+    nextObjectCopy[target] = !nextObject[target];
+    return nextObjectCopy;
   },
   $unset: function(value, nextObject, spec, originalObject) {
     invariant(
@@ -159,7 +161,7 @@ function invariantPushAndUnshift(value, spec, command) {
 }
 
 function invariantToggle(target, nextObject) {
-  const type = typeof nextObject[target];
+  var type = typeof nextObject[target];
 
   invariant(
     type === 'boolean',

--- a/index.js
+++ b/index.js
@@ -101,10 +101,14 @@ var defaultCommands = {
     invariantSet(spec);
     return value;
   },
-  $toggle: function(target, nextObject, spec) {
-    invariantToggle(target, nextObject);
-    var nextObjectCopy = copy(nextObject);
-    nextObjectCopy[target] = !nextObject[target];
+  $toggle: function(targets, nextObject) {
+    invariantToggle(targets, nextObject);
+    var nextObjectCopy = targets.length ? copy(nextObject) : nextObject;
+
+    targets.forEach(function(target) {
+      nextObjectCopy[target] = !nextObject[target];
+    });
+
     return nextObjectCopy;
   },
   $unset: function(value, nextObject, spec, originalObject) {
@@ -160,13 +164,12 @@ function invariantPushAndUnshift(value, spec, command) {
   );
 }
 
-function invariantToggle(target, nextObject) {
-  var type = typeof nextObject[target];
-
+function invariantToggle(value) {
   invariant(
-    type === 'boolean',
-    'toggle(): expected target to be a boolean; got %s.',
-    type
+    Array.isArray(value),
+    'update(): expected spec of $toggle to be an array; got %s. ' +
+    'Did you forget to wrap the key(s) in an array?',
+    value
   );
 }
 

--- a/index.js
+++ b/index.js
@@ -101,6 +101,10 @@ var defaultCommands = {
     invariantSet(spec);
     return value;
   },
+  $toggle: function(target, nextObject, spec) {
+    invariantToggle(target, nextObject);
+    return assign({}, nextObject, {[target]: !nextObject[target]});
+  },
   $unset: function(value, nextObject, spec, originalObject) {
     invariant(
       Array.isArray(value),
@@ -151,6 +155,16 @@ function invariantPushAndUnshift(value, spec, command) {
     'Did you forget to wrap your parameter in an array?',
     command,
     specValue
+  );
+}
+
+function invariantToggle(target, nextObject) {
+  const type = typeof nextObject[target];
+
+  invariant(
+    type === 'boolean',
+    'toggle(): expected target to be a boolean; got %s.',
+    type
   );
 }
 

--- a/test.js
+++ b/test.js
@@ -145,16 +145,18 @@ describe('update', function() {
   });
 
   describe('$toggle', function() {
-    it('toggles false to true', function() {
-      expect(update({a: false}, {$toggle: 'a'})).toEqual({a: true});
-    });
-    it('toggles true to false', function() {
-      expect(update({a: true}, {$toggle: 'a'})).toEqual({a: false});
+    it('toggles false to true and true to false', function() {
+      expect(update({a: false, b: true}, {$toggle: ['a', 'b']})).toEqual({a: true, b: false});
     });
     it('does not mutate the original object', function() {
       var obj = {a: false};
-      update(obj, {$toggle: 'a'});
+      update(obj, {$toggle: ['a']});
       expect(obj).toEqual({a: false});
+    });
+    it('keeps reference equality when possible', function() {
+      var original = {a: false};
+      expect(update(original, {$toggle: []})).toBe(original);
+      expect(update(original, {$toggle: ['a']})).toNotBe(original);
     });
   });
 

--- a/test.js
+++ b/test.js
@@ -145,6 +145,12 @@ describe('update', function() {
   });
 
   describe('$toggle', function() {
+    it('only takes an array as spec', function() {
+      expect(update.bind(null, {a: false}, {$toggle: 'a'})).toThrow(
+        'update(): expected spec of $toggle to be an array; got a. Did you ' +
+        'forget to wrap the key(s) in an array?'
+      );
+    });
     it('toggles false to true and true to false', function() {
       expect(update({a: false, b: true}, {$toggle: ['a', 'b']})).toEqual({a: true, b: false});
     });

--- a/test.js
+++ b/test.js
@@ -144,6 +144,20 @@ describe('update', function() {
     });
   });
 
+  describe('$toggle', function() {
+    it('toggles false to true', function() {
+      expect(update({a: false}, {$toggle: 'a'})).toEqual({a: true});
+    });
+    it('toggles true to false', function() {
+      expect(update({a: true}, {$toggle: 'a'})).toEqual({a: false});
+    });
+    it('does not mutate the original object', function() {
+      var obj = {a: false};
+      update(obj, {$toggle: 'a'});
+      expect(obj).toEqual({a: false});
+    });
+  });
+
   describe('$unset', function() {
     it('unsets', function() {
       expect(update({a: 'b'}, {$unset: ['a']}).a).toBe(undefined);
@@ -315,7 +329,7 @@ describe('update', function() {
       expect(update.bind(null, {a: 'b'}, spec)).toThrow(
         'update(): You provided an invalid spec to update(). The spec ' +
         'and every included key path must be plain objects containing one ' +
-        'of the following commands: $push, $unshift, $splice, $set, $unset, ' +
+        'of the following commands: $push, $unshift, $splice, $set, $toggle, $unset, ' +
         '$merge, $apply.'
       );
     });


### PR DESCRIPTION
Sometimes, it's useful to be able to just toggle a boolean field. Right now I'd have to write something like this:

```javascript
const obj = { a: false };
update(obj, {a: {$set: !obj.a}});
```

This PR makes it possible to go like:

```javascript
const obj = {a: false};
update(obj, {$toggle: ['a']});
```