### PR TITLE
Use Array.isArray instead of instanceof

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var getAllKeys = typeof Object.getOwnPropertySymbols === 'function' ?
 
 /* istanbul ignore next */
 function copy(object) {
-  if (object instanceof Array) {
+  if (Array.isArray(object)) {
     return assign(object.constructor(object.length), object)
   } else if (object && typeof object === 'object') {
     var prototype = object.constructor && object.constructor.prototype


### PR DESCRIPTION
It looks like an obscure problem, but I just had to stumble upon it...

I dove into the `copy` function while tracking a strange problem in my tests that happend after update to `2.4.0`. In my case the `object` was an array (`Array.isArray(object)` returns `true`), but it was probably created in a context different from the one where the library was initialized, so `object instanceof Array` was `false`:
```
> object.constructor
function Array() { [native code] }

> Array
function Array() { [native code] }

> object.constructor === Array
false
```

This caused the array to be treated as an object and so this was causing the problems later on:
```
var prototype = object.constructor && object.constructor.prototype
return assign(Object.create(prototype || null), object);
```

But the root cause is still the detection of an array.

`Array.isArray` is used in a lot of places in the code already, so I assume that compat is not a problem?