### PR TITLE
Introduce TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for immutability-helper
+// Project: Immutability helper
+
+export = update
+
+declare function update<T>(data: T, query: update.Query<T>): T
+
+export namespace update {
+  function newContext(): typeof update
+  function extend<T>(
+    command: Command,
+    handler: (param: CommandArg, old: T) => T
+  )
+
+  type Command = string
+  type CommandArg = any
+
+  type ObjectOperator<T> =
+    | {$set: any}
+    | {$toggle: Array<keyof T>}
+    | {$unset: Array<keyof T>}
+    | {$merge: Partial<T>}
+    | {$apply: (old: T) => any}
+    | ((old: T) => any)
+
+  type MapAndSetOperators = {$add: Array<any>} | {$remove: Array<string>}
+
+  type ArrayOperator<T> =
+    | {$push: T}
+    | {$unshift: T}
+    | {$splice: [number, number][]}
+
+  type Operators<T> =
+    | ObjectOperator<T>
+    | ArrayOperator<T>
+    | MapAndSetOperators<T>
+
+  type Tree<T> = {[K in keyof T]?: Query<T[K]>}
+
+  type Query<T> = Tree<T> | Operators<T>
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.6.0",
   "description": "mutate a copy of data without changing the original source",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "test-cov": "nyc npm test && nyc report --reporter=lcov",
     "test-travis": "nyc npm test && nyc report --reporter=lcov",


### PR DESCRIPTION
Following back from #57. This pull request introduces some _very_ rough types as a proof of concept. I'd love to receive more feedback from someone who's more proficient than me with TypeScript with some insights:

1. Is there any way to have _conditionals_ for generics? We can separate that way the commands for Objects from those that are written for Arrays. Also would be nice to separate the Map & Set commands. I know, they are forced on the runtime using invariants but having a static way to catch the bugs would be awesome.
2. A way to augment the `Operators<T>` in the user land. We would need that because of the custom defined  commands. We could of course add `{[string]: any}` as the enum value but we'll loose type information from the rest of the commands that way.

Do you have any thoughts? I would love any feedback on that.

<hr>

@gnapse The `$apply` as a function is handled [here](https://github.com/kolodny/immutability-helper/pull/74/files#diff-b52768974e6bc0faccb7d4b75b162c99R24) properly.