### PR TITLE
Fix Typescript generic type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare function update<K, V>(
   query: MapOperators<K, V>,
 ): ReadonlyMap<K, V>
 
-declare function update<T>(data: T, query: Query<T>): object
+declare function update<T>(data: T, query: Query<T>): T
 
 type Tree<T> = {[K in keyof T]?: Query<T[K]>}
 type Query<T> =


### PR DESCRIPTION
This PR fixes wrong return type in TypeScript.

Example:
```js
import update from 'immutability-helper';

interface MyMap {
  foo: string;
}

function setFoo(state: MyMap): MyMap {
    return update(
        state,
        {foo: {$set: 'bar'}}
    );
}
```
Compile failed with error
```bash
TS2322: Type 'object' is not assignable to type 'MyMap'.
Property 'foo' is missing in type '{}'.
```
  