### PR TITLE
fix($types): support array index

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export = update
 
 declare function update<T>(
   data: ReadonlyArray<T>,
-  query: ArrayOperators<T> | any,
+  query: ArrayOperators<T>,
 ): ReadonlyArray<T>
 
 declare function update<T>(
@@ -38,6 +38,7 @@ type ArrayOperators<T> =
   | {$push: T}
   | {$unshift: T}
   | {$splice: Array<[number, number]>}
+  | {[customCommand: string]: any}
 
 type MapOperators<K, V> = {$add: Array<[K, V]>} | {$remove: K[]}
 type SetOperators<T> = {$add: T[]} | {$remove: T[]}

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,10 +3,9 @@
 
 export = update
 
-// declare function update<T>(data: T, query: update.Query<T>): T
 declare function update<T>(
   data: ReadonlyArray<T>,
-  query: ArrayOperators<T>,
+  query: ArrayOperators<T> | any,
 ): ReadonlyArray<T>
 
 declare function update<T>(


### PR DESCRIPTION
Temporary fix for #84.

Here's a VERY bad way of allowing nested array indexing in queries. Here's a very rough [reproduction](https://www.typescriptlang.org/play/#src=declare%20function%20update%3CT%3E(%0D%0A%20%20data%3A%20ReadonlyArray%3CT%3E%2C%0D%0A%20%20query%3A%20Query%3CT%3E%2C%0D%0A)%3A%20ReadonlyArray%3CT%3E%0D%0A%0D%0Adeclare%20function%20update%3CT%3E(%0D%0A%20%20data%3A%20ReadonlySet%3CT%3E%2C%0D%0A%20%20query%3A%20SetOperators%3CT%3E%2C%0D%0A)%3A%20ReadonlySet%3CT%3E%0D%0A%0D%0Adeclare%20function%20update%3CK%2C%20V%3E(%0D%0A%20%20data%3A%20ReadonlyMap%3CK%2C%20V%3E%2C%0D%0A%20%20query%3A%20MapOperators%3CK%2C%20V%3E%2C%0D%0A)%3A%20ReadonlyMap%3CK%2C%20V%3E%0D%0A%0D%0Adeclare%20function%20update%3CT%3E(data%3A%20T%2C%20query%3A%20Query%3CT%3E)%3A%20T%0D%0A%0D%0Atype%20Tree%3CT%3E%20%3D%20%7B%5BK%20in%20keyof%20T%5D%3F%3A%20Query%3CT%5BK%5D%3E%7D%0D%0Atype%20Query%3CT%3E%20%3D%0D%0A%20%20%7C%20Tree%3CT%3E%0D%0A%20%20%7C%20ObjectOperators%3CT%3E%0D%0A%20%20%7C%20ArrayOperators%3Cany%3E%0D%0A%20%20%7C%20SetOperators%3Cany%3E%0D%0A%0D%0Atype%20ObjectOperators%3CT%3E%20%3D%0D%0A%20%20%7C%20%7B%24set%3A%20any%7D%0D%0A%20%20%7C%20%7B%24toggle%3A%20Array%3Ckeyof%20T%3E%7D%0D%0A%20%20%7C%20%7B%24unset%3A%20Array%3Ckeyof%20T%3E%7D%0D%0A%20%20%7C%20%7B%24merge%3A%20Partial%3CT%3E%7D%0D%0A%20%20%7C%20%7B%24apply%3A%20(old%3A%20T)%20%3D%3E%20T%7D%0D%0A%20%20%7C%20((old%3A%20T)%20%3D%3E%20any)%0D%0Atype%20ArrayOperators%3CT%3E%20%3D%0D%0A%20%20%7C%20%7B%24push%3A%20T%7D%0D%0A%20%20%7C%20%7B%24unshift%3A%20T%7D%0D%0A%20%20%7C%20%7B%24splice%3A%20Array%3C%5Bnumber%2C%20number%5D%3E%7D%0D%0A%0D%0Atype%20MapOperators%3CK%2C%20V%3E%20%3D%20%7B%24add%3A%20Array%3C%5BK%2C%20V%5D%3E%7D%20%7C%20%7B%24remove%3A%20K%5B%5D%7D%0D%0Atype%20SetOperators%3CT%3E%20%3D%20%7B%24add%3A%20T%5B%5D%7D%20%7C%20%7B%24remove%3A%20T%5B%5D%7D%0D%0A%0D%0Adeclare%20namespace%20update%20%7B%0D%0A%20%20function%20newContext()%3A%20typeof%20update%0D%0A%20%20function%20extend%3CT%3E(%0D%0A%20%20%20%20command%3A%20Command%2C%0D%0A%20%20%20%20handler%3A%20(param%3A%20CommandArg%2C%20old%3A%20T)%20%3D%3E%20T%2C%0D%0A%20%20)%3A%20void%0D%0A%0D%0A%20%20type%20Command%20%3D%20string%0D%0A%20%20type%20CommandArg%20%3D%20any%0D%0A%7D%0D%0A%0D%0Aconst%20collection%20%3D%20%5B1%2C%202%2C%20%7B'2'%3A%20'asd'%2C%20a%3A%20%5B12%2C%2017%2C%2015%5D%7D%5D%3B%0D%0Aconst%20newCollection%20%3D%20update(collection%2C%20%7B2%3A%20%7Ba%3A%20%7B%24splice%3A%20%5B%5B1%2C%201%2C%2013%2C%2014%5D%5D%7D%7D%7D)%3B%0D%0A) of the problem for the TypeScript experts that may be able to help us get a more type-safe solution for this problem.

<hr>

There definitely should be a way of not loosing the type data here. I imagine the solution to look like (imaginary syntax that doesn't exist in TypeScript :) ):

```typescript
type Tree<T> = 
  // If is object
  {[K in keyof T]?: Query<T[K]>}
  |
  // if is array
  {[I in indexesOf T]?: Query<T[I]>}
```

Is there something like `I in indexesOf T` in TypeScript? I imagine there's no way of getting such information from just static analysis.

cc. @kolodny @andy-ms