### PR TITLE
Adds update functionality to Map entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,11 @@ function newContext() {
           if (nextObject === object) {
             nextObject = copy(object);
           }
-          nextObject[key] = nextValueForKey;
+          if (type(nextObject) === 'Map') {
+            nextObject.set(key, nextValueForKey);
+          } else {
+            nextObject[key] = nextValueForKey;
+          }
         }
       }
     })

--- a/test.js
+++ b/test.js
@@ -529,4 +529,20 @@ describe('update', function() {
     expect(state2.items.top).toBe(0)
   });
 
+  it('supports Maps', function() {
+    var state = new Map([
+      ['mapKey', 'mapValue']
+    ]);
+
+    var updatedState = update(state, {
+      ['mapKey']: {$set: 'updatedMapValue' }
+    });
+
+    expect(updatedState).toEqual(
+      new Map([
+        ['mapKey', 'updatedMapValue']
+      ])
+    );
+  });
+
 });


### PR DESCRIPTION
Resolves issue #89 by supporting the Map set syntax in the update
function.

Previously, this would result in a Map that would be of the form:
```
Map {
  'mapKey' => { value: 'mapValue' },
  mapKey: { value: 'updatedMapValue' } }
```