### PR TITLE
operator $splice typing fixed

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ export type Spec<T, C extends CustomCommands<object> = never> =
 type ArraySpec<T, C extends CustomCommands<object>> =
   | { $push: T[] }
   | { $unshift: T[] }
-  | { $splice: Array<[number] | [number, number] | [number, number, T]> }
+  | { $splice: Array<[number, number?] | [number, number, ...T[]]> }
   | { [index: string]: Spec<T, C> }; // Note that this does not type check properly if index: number.
 
 type MapSpec<K, V> =


### PR DESCRIPTION
According to `typescript/lib/lib.es5.d.ts`
the type of `Array.prototype.splice` is:

```ts
splice(start: number, deleteCount?: number): T[];
splice(start: number, deleteCount: number, ...items: T[]): T[];
```
