### PR TITLE
Lighten publish size, show badges

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+end_of_line = lf
 
 [*.md]
 trim_trailing_whitespace = false

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,8 @@
 node_modules/
 .nyc_output/
 coverage/
+immutability-helper-*/
+.travis.yml
+test.js
+ts*.json
+typings-test.ts

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ immutability-helper
 [![Build status][travis-image]][travis-url]
 [![Test coverage][coveralls-image]][coveralls-url]
 [![Downloads][downloads-image]][downloads-url]
+[![Install size][install-size-image]][install-size-url]
+[![index.js size][index-js-size-image]][index-js-url]
+[![Gzip index.js size][gzip-index-js-size-image]][index-js-url]
 
 Mutate a copy of data without changing the original source
 
@@ -322,3 +325,8 @@ myUpdate.extend('$foo', function(value, original) {
 [coveralls-url]: https://coveralls.io/r/kolodny/immutability-helper
 [downloads-image]: http://img.shields.io/npm/dm/immutability-helper.svg?style=flat-square
 [downloads-url]: https://npmjs.org/package/immutability-helper
+[install-size-image]: https://packagephobia.now.sh/badge?p=immutability-helper
+[install-size-url]: https://packagephobia.now.sh/result?p=immutability-helper
+[index-js-size-image]: http://img.badgesize.io/kolodny/immutability-helper/master/index.js?label=index.js
+[index-js-url]: https://github.com/kolodny/immutability-helper/blob/master/index.js
+[gzip-index-js-size-image]: http://img.badgesize.io/kolodny/immutability-helper/master/index.js?compression=gzip&label=gzip%20index.js


### PR DESCRIPTION
[![Install size][install-size-image]][install-size-url] [![index.js size][index-js-size-image]][index-js-url] [![Gzip index.js size][gzip-index-js-size-image]][index-js-url]

Anyone visiting [Package Phobia][install-size-url] will see that this package currently has an install size @120kB. That might turn some folks away from installing the package, but actually the [index.js](https://github.com/kolodny/immutability-helper/blob/master/index.js
) file is pretty small @ 8.16kB, especially when gzipped @ 2.01kB.

_Note: [invariant](https://www.npmjs.com/package/invariant) is causing most of this footprint._

## Current Master
![image](https://user-images.githubusercontent.com/1058243/49267661-2b28ea80-f421-11e8-916d-c6f799a4e84e.png)

[install-size-image]: https://packagephobia.now.sh/badge?p=immutability-helper
[install-size-url]: https://packagephobia.now.sh/result?p=immutability-helper
[index-js-size-image]: http://img.badgesize.io/kolodny/immutability-helper/master/index.js?label=index.js
[index-js-url]: https://github.com/kolodny/immutability-helper/blob/master/index.js
[gzip-index-js-size-image]: http://img.badgesize.io/kolodny/immutability-helper/master/index.js?compression=gzip&label=gzip%20index.js