### PR TITLE
Support complex specs inside of Maps in typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ export default _default;
 export declare type CustomCommands<T> = T & {
     __noInferenceCustomCommandsBrand: any;
 };
-export declare type Spec<T, C extends CustomCommands<object> = never> = (T extends (Array<infer U> | ReadonlyArray<infer U>) ? ArraySpec<U, C> : T extends (Map<infer K, infer V> | ReadonlyMap<infer K, infer V>) ? MapSpec<K, V> : T extends (Set<infer X> | ReadonlySet<infer X>) ? SetSpec<X> : T extends object ? ObjectSpec<T, C> : never) | {
+export declare type Spec<T, C extends CustomCommands<object> = never> = (T extends (Array<infer U> | ReadonlyArray<infer U>) ? ArraySpec<U, C> : T extends (Map<infer K, infer V> | ReadonlyMap<infer K, infer V>) ? MapSpec<K, V, C> : T extends (Set<infer X> | ReadonlySet<infer X>) ? SetSpec<X> : T extends object ? ObjectSpec<T, C> : never) | {
     $set: T;
 } | {
     $apply: (v: T) => T;
@@ -26,14 +26,12 @@ declare type ArraySpec<T, C extends CustomCommands<object>> = {
 } | {
     [index: string]: Spec<T, C>;
 };
-declare type MapSpec<K, V> = {
+declare type MapSpec<K, V, C extends CustomCommands<object>> = {
     $add: ReadonlyArray<[K, V]>;
 } | {
     $remove: ReadonlyArray<K>;
 } | {
-    [key: string]: {
-        $set: V;
-    };
+    [key: string]: Spec<V, C>;
 };
 declare type SetSpec<T> = {
     $add: ReadonlyArray<T>;

--- a/index.ts
+++ b/index.ts
@@ -325,7 +325,7 @@ export type CustomCommands<T> = T & { __noInferenceCustomCommandsBrand: any };
 export type Spec<T, C extends CustomCommands<object> = never> =
   | (
       T extends (Array<infer U> | ReadonlyArray<infer U>) ? ArraySpec<U, C> :
-      T extends (Map<infer K, infer V> | ReadonlyMap<infer K, infer V>) ? MapSpec<K, V> :
+      T extends (Map<infer K, infer V> | ReadonlyMap<infer K, infer V>) ? MapSpec<K, V, C> :
       T extends (Set<infer X> | ReadonlySet<infer X>) ? SetSpec<X> :
       T extends object ? ObjectSpec<T, C> :
       never
@@ -341,10 +341,10 @@ type ArraySpec<T, C extends CustomCommands<object>> =
   | { $splice: ReadonlyArray<[number, number?] | [number, number, ...T[]]> }
   | { [index: string]: Spec<T, C> }; // Note that this does not type check properly if index: number.
 
-type MapSpec<K, V> =
+type MapSpec<K, V, C extends CustomCommands<object>> =
   | { $add: ReadonlyArray<[K, V]> }
   | { $remove: ReadonlyArray<K> }
-  | { [key: string]: { $set: V } };
+  | { [key: string]: Spec<V, C> };
 
 type SetSpec<T> =
   | { $add: ReadonlyArray<T> }


### PR DESCRIPTION
The MapSpec type was unnecessarily strict about the what could be allowed in $set commands. 

Resolves #161 