### PR TITLE
Add support for "transactions"

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -84,6 +84,12 @@ export class Context {
   }
   public update<T, C extends CustomCommands<object> = never>(
     object: T,
+    ...$specs: Spec<T, C>[],
+  ): T {
+      return $specs.reduce((currState, $spec) => this.updateSingle(currState, $spec), object)
+  }
+  private updateSingle<T, C extends CustomCommands<object> = never>(
+    object: T,
     $spec: Spec<T, C>,
   ): T {
     const spec = (typeof $spec === 'function') ? { $apply: $spec } : $spec;


### PR DESCRIPTION
Sometimes I need to apply multiple changes to the state object at the same time. At the beginning, I was wrapping the result of an `update` with another `update`, but at some point, it started to be too verbose so I came up with a helper that does what I'm proposing in this change. It basically changes the `update` interface so that it receives an array of $specs as a spread so that it's still backward compatible with the original update interface.

This would allow users to do:
```
update(state, 
  {a: {b: {$set: change_1}}}, 
  {c: {d: {$set: change_2}}})
```
Instead of
```
update(update(state, 
  {a: {b: {$set: change_1}}}), 
  {c: {d: {$set: change_2}}}))
```

What do you think?